### PR TITLE
fix(ci): publish signed release artifacts reliably

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -75,15 +75,17 @@ jobs:
 
       - name: Prepare signed release APKs
         if: steps.keycheck.outputs.available == 'true'
-        env:
-          SIGNED_RELEASE_FILES: ${{ steps.sign.outputs.signedReleaseFiles }}
         run: |
           mkdir -p app/build/publish
-          IFS=':' read -ra files <<< "$SIGNED_RELEASE_FILES"
-          for file in "${files[@]}"; do
-            test -n "$file"
-            cp "$file" app/build/publish/
-          done
+          shopt -s nullglob
+          signed_files=(app/build/outputs/apk/release/*-signed.apk)
+          if (( ${#signed_files[@]} == 0 )); then
+            echo "::error::Signing completed but produced no signed APK files."
+            find app/build/outputs/apk/release -maxdepth 1 -type f -print
+            exit 1
+          fi
+          cp "${signed_files[@]}" app/build/publish/
+          ls -lh app/build/publish
 
       - name: Upload release APKs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Existing semantic-version tag to publish
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -12,8 +18,26 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve release tag
+        id: release
+        env:
+          REQUESTED_TAG: ${{ inputs.tag }}
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            tag="$REQUESTED_TAG"
+          else
+            tag="$GITHUB_REF_NAME"
+          fi
+          if [[ ! "$tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Release tag '$tag' must use the format v1.2.3."
+            exit 1
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release.outputs.tag }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -65,19 +89,22 @@ jobs:
           BUILD_TOOLS_VERSION: "36.0.0"
 
       - name: Prepare signed release APKs
-        env:
-          SIGNED_RELEASE_FILES: ${{ steps.sign.outputs.signedReleaseFiles }}
         run: |
           mkdir -p app/build/publish
-          IFS=':' read -ra files <<< "$SIGNED_RELEASE_FILES"
-          for file in "${files[@]}"; do
-            test -n "$file"
-            cp "$file" app/build/publish/
-          done
+          shopt -s nullglob
+          signed_files=(app/build/outputs/apk/release/*-signed.apk)
+          if (( ${#signed_files[@]} == 0 )); then
+            echo "::error::Signing completed but produced no signed APK files."
+            find app/build/outputs/apk/release -maxdepth 1 -type f -print
+            exit 1
+          fi
+          cp "${signed_files[@]}" app/build/publish/
+          ls -lh app/build/publish
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ steps.release.outputs.tag }}
           files: app/build/publish/*.apk
           fail_on_unmatched_files: true
           generate_release_notes: true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Process**
  * Added support for manually triggered releases using a required semantic-version tag.
  * Improved tag validation and checkout consistency for automated and manual releases.
  * Release preparation now detects and publishes all signed APK files.
  * Added clear failure reporting when no signed APKs are produced.
  * Updated GitHub Release creation to use the resolved release tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->